### PR TITLE
Bump Laravel Mix to 6

### DIFF
--- a/stubs/package.json
+++ b/stubs/package.json
@@ -2,16 +2,15 @@
   "private": true,
   "scripts": {
     "dev": "npm run development",
-    "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "npm run development -- --watch",
-    "watch-poll": "npm run watch -- --watch-poll",
-    "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --disable-host-check --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "development": "mix",
+    "watch": "mix watch",
+    "watch-poll": "mix watch -- --watch-options-poll=1000",
+    "hot": "mix watch --hot",
     "prod": "npm run production",
-    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "production": "mix --production"
   },
   "devDependencies": {
-    "cross-env": "^7.0",
-    "laravel-mix": "^5.0.1",
+    "laravel-mix": "^6.0.6",
     "resolve-url-loader": "^3.1.0"
   },
   "dependencies": {

--- a/stubs/package.json
+++ b/stubs/package.json
@@ -11,7 +11,8 @@
   },
   "devDependencies": {
     "laravel-mix": "^6.0.6",
-    "resolve-url-loader": "^3.1.0"
+    "resolve-url-loader": "^3.1.0",
+    "postcss": "^8.1.14"
   },
   "dependencies": {
     "jquery": "^3.5.1",


### PR DESCRIPTION
Update packages.json to bump laravel-mix to version 6 as promised in #3 . 
cross-env is no longer required.